### PR TITLE
Tlm rx

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+  workflow_dispatch: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nucleus_common = { path= "../nucleus_common" }
-
 nng = "0.5.1"
 rmp = "0.8.9"
 rmp-serde = "0.14.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 nucleus_common = { path= "../nucleus_common" }
 
 nng = "0.5.1"
+rmp = "0.8.9"
 rmp-serde = "0.14.4"
 
 #tmp

--- a/src/bin/tlm_rx.rs
+++ b/src/bin/tlm_rx.rs
@@ -4,7 +4,6 @@ use std::io::{Cursor, Write};
 use std::net::{SocketAddr, UdpSocket};
 use std::sync::mpsc::{Receiver, SyncSender};
 use std::thread;
-use std::time::Duration;
 
 use nng;
 use rmp;

--- a/src/bin/tlm_rx.rs
+++ b/src/bin/tlm_rx.rs
@@ -1,11 +1,14 @@
 extern crate rmp_serde as rmps;
 
-use std::thread;
 use std::io::Cursor;
 use std::net::{SocketAddr, UdpSocket};
 use std::sync::mpsc::{Receiver, SyncSender};
+use std::thread;
 use std::time::Duration;
 
+use nng;
+use nng::Protocol;
+use rmp;
 use rmps::Deserializer;
 use serde;
 
@@ -17,12 +20,10 @@ struct LatLon {
     lon: f32,
 }
 
-fn eth_rx_loop(_thread_tx: SyncSender<u8>) {
+fn eth_rx_loop(thread_tx: SyncSender<Vec<u8>>) {
     let mut buf = [0; 256];
     assert!(buf[255] == 0);
 
-    let mut cur = Cursor::new(&buf[..]);
-    let mut deserializer = Deserializer::new(cur);
 
     let socket = match UdpSocket::bind(SocketAddr::from(RX_ADDR)) {
         Ok(v) => v,
@@ -35,40 +36,61 @@ fn eth_rx_loop(_thread_tx: SyncSender<u8>) {
     //socket.set_read_timeout(Some(Duration::from_millis(1000))).unwrap();
 
     loop {
-        let (_size, _sender_addr) = match socket.recv_from(&mut buf[..]) {
-            Ok(v) => v,
+        let (size, _sender_addr) = match socket.recv_from(&mut buf[..]) {
+            Ok(v) => {
+                println!("Received {} byes", v.0);
+                v
+            },
             Err(e) => {
                 println! {"Error receiving message: {:?}", e};
                 continue;
             }
         };
         //let filled_buf = &buf[..size];
+        //let mut cur = Cursor::new(&buf[..]);
+        //let mut deserializer = Deserializer::new(cur);
 
-        let actual: LatLon = serde::Deserialize::deserialize(&mut deserializer).unwrap();
-        println!("Received: {:?}", actual)
+        //let actual: LatLon = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+        //let actual = rmp::decode::read_ext_meta(&mut cur);
+        //println!("Received: {:?}", actual);
+
+        thread_tx.send(buf[..size].to_vec());
     }
 }
 
-fn can_rx_loop(thread_tx: SyncSender<u8>) {
+fn can_rx_loop(thread_tx: SyncSender<Vec<u8>>) {
     for _ in 0..255 {
         thread::sleep(Duration::from_millis(5));
-        thread_tx.send(0x55);
+        //thread_tx.send(0x55);
     }
 }
 
-fn ipc_tx_loop(thread_rx: Receiver<u8>) {
+fn ipc_tx_loop(thread_rx: Receiver<Vec<u8>>) {
+    // TODO move initialization of sockets to init function, moving into thread
+    let s = nng::Socket::new(nng: Protocol::Pub0)?;
+
+
     loop {
-        match thread_rx.recv() {
-            Ok(v) => println!("Received: {}", v),
+        let buf = match thread_rx.recv() {
+            Ok(v) => v,
             Err(_) => {
                 println!("Channel disconnected");
                 break;
             }
-        }
+        };
+
+        // grab extension code and size of data
+        let ext_meta = rmp::decode::read_ext_meta(&mut Cursor::new(&buf)).unwrap();
+
+        // chop off extension, this might be janky? TODO find a better way
+        let data = buf[(buf.len() - (ext_meta.size as usize))..].to_vec();
+
+        // publish message on nng
     }
 }
 
 fn main() {
+    // TODO move setup of sockets and all to an init function, moving the objects into the threads
     let (eth_thread_sender, thread_rx) = std::sync::mpsc::sync_channel(1);
     let can_thread_sender = eth_thread_sender.clone();
 

--- a/src/bin/tlm_rx.rs
+++ b/src/bin/tlm_rx.rs
@@ -1,0 +1,86 @@
+extern crate rmp_serde as rmps;
+
+use std::thread;
+use std::io::Cursor;
+use std::net::{SocketAddr, UdpSocket};
+use std::sync::mpsc::{Receiver, SyncSender};
+use std::time::Duration;
+
+use rmps::Deserializer;
+use serde;
+
+static RX_ADDR: ([u8; 4], u16) = ([127, 0, 0, 1], 6666);
+
+#[derive(Debug, PartialEq, serde::Deserialize)]
+struct LatLon {
+    lat: f32,
+    lon: f32,
+}
+
+fn eth_rx_loop(_thread_tx: SyncSender<u8>) {
+    let mut buf = [0; 256];
+    assert!(buf[255] == 0);
+
+    let mut cur = Cursor::new(&buf[..]);
+    let mut deserializer = Deserializer::new(cur);
+
+    let socket = match UdpSocket::bind(SocketAddr::from(RX_ADDR)) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("Creating socket error: {:?}", e);
+            return ();
+        }
+    };
+
+    //socket.set_read_timeout(Some(Duration::from_millis(1000))).unwrap();
+
+    loop {
+        let (_size, _sender_addr) = match socket.recv_from(&mut buf[..]) {
+            Ok(v) => v,
+            Err(e) => {
+                println! {"Error receiving message: {:?}", e};
+                continue;
+            }
+        };
+        //let filled_buf = &buf[..size];
+
+        let actual: LatLon = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+        println!("Received: {:?}", actual)
+    }
+}
+
+fn can_rx_loop(thread_tx: SyncSender<u8>) {
+    for _ in 0..255 {
+        thread::sleep(Duration::from_millis(5));
+        thread_tx.send(0x55);
+    }
+}
+
+fn ipc_tx_loop(thread_rx: Receiver<u8>) {
+    loop {
+        match thread_rx.recv() {
+            Ok(v) => println!("Received: {}", v),
+            Err(_) => {
+                println!("Channel disconnected");
+                break;
+            }
+        }
+    }
+}
+
+fn main() {
+    let (eth_thread_sender, thread_rx) = std::sync::mpsc::sync_channel(1);
+    let can_thread_sender = eth_thread_sender.clone();
+
+    let eth_rx_handler = thread::spawn(move || { eth_rx_loop(eth_thread_sender) });
+    let can_rx_hander = thread::spawn(|| { can_rx_loop(can_thread_sender) });
+    let ipc_tx_handler = thread::spawn(|| { ipc_tx_loop(thread_rx) });
+
+    match eth_rx_handler.join() {
+        Ok(_) => println!("eth_rx Shit worked out"),
+        Err(e) => println!("eth_rx Error: {:?}", e)
+    }
+    can_rx_hander.join().unwrap();
+
+    ipc_tx_handler.join().unwrap();
+}


### PR DESCRIPTION
merging in the first prototype cut of the Tlm Rx app.

This app's main purpose is to relay messages from the CAN and Ethernet interfaces.  The messages are expected to be in extended type [messagepack ](https://msgpack.org/) messages.  This extended type in the future will be used to determine which [nng](https://github.com/nanomsg/nng) topic the message will be published on. 

Please let me know how I could improve the blocking IO or the general performance/flow/safety of this.  

I would prefer to wait to merge until some folks have been able to review and approve.