### PR TITLE
SIM: eliminate dead code warnings

### DIFF
--- a/simulator/src/async_sim.rs
+++ b/simulator/src/async_sim.rs
@@ -1,7 +1,7 @@
 use crate::simulate;
 use crate::{SimCommands, SimOutput};
 use std::sync::mpsc;
-use std::sync::mpsc::{Receiver, SendError, Sender};
+use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -140,6 +140,8 @@ fn init_log_file() -> csv::Writer<File> {
             "ballast_mass_kg",
             "vent_pwm",
             "dump_pwm",
+            "gross_lift_N",
+            "free_lift_N",
         ])
         .unwrap();
     writer
@@ -156,6 +158,8 @@ fn log_to_file(sim_output: &SimOutput, writer: &mut csv::Writer<File>) {
             sim_output.ballast_mass.to_string(),
             sim_output.vent_pwm.to_string(),
             sim_output.dump_pwm.to_string(),
+            sim_output.gross_lift.to_string(),
+            sim_output.free_lift.to_string(),
         ])
         .unwrap();
     writer.flush().unwrap();

--- a/simulator/src/balloon.rs
+++ b/simulator/src/balloon.rs
@@ -20,7 +20,6 @@ pub enum BalloonType {
 
 #[derive(Copy, Clone)]
 pub struct Balloon {
-    part_no: BalloonType,
     pub lift_gas: gas::GasVolume,
     pub mass: f32, // balloon mass
     pub max_volume: f32, // burst above this volume
@@ -34,7 +33,6 @@ impl Balloon {
         match part_no {
             BalloonType::Hab800 => {
                 Balloon {
-                    part_no,
                     lift_gas,
                     mass: 0.8,
                     max_volume: volume_from_diameter(7.0),
@@ -45,7 +43,6 @@ impl Balloon {
             },
             BalloonType::Hab1200 => {
                 Balloon {
-                    part_no,
                     lift_gas,
                     mass: 1.2,
                     max_volume: volume_from_diameter(8.63),
@@ -56,7 +53,6 @@ impl Balloon {
             },
             BalloonType::Hab1500 => {
                 Balloon {
-                    part_no,
                     lift_gas,
                     mass: 1.5,
                     max_volume: volume_from_diameter(9.44),
@@ -67,7 +63,6 @@ impl Balloon {
             },
             BalloonType::Hab2000 => {
                 Balloon {
-                    part_no,
                     lift_gas,
                     mass: 2.0,
                     max_volume: volume_from_diameter(10.54),
@@ -78,7 +73,6 @@ impl Balloon {
             },
             BalloonType::Hab3000 => {
                 Balloon {
-                    part_no,
                     lift_gas,
                     mass: 3.0,
                     max_volume: volume_from_diameter(13.0),

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -20,4 +20,6 @@ pub struct SimOutput {
     pub lift_gas_mass: f32,
     pub vent_pwm: f32,
     pub dump_pwm: f32,
+    pub gross_lift: f32,
+    pub free_lift: f32,
 }


### PR DESCRIPTION
- removes unused imports
- adds `gross_lift` and `free_lift` as outputs. these are essentially derived telemetry points
- removes the `part_no` attribute from the balloon type. it is only used to initialize the balloon and we dont need an attribute for that