### PR TITLE
LIB: update nng and rmp-serde to the latest major release

### DIFF
--- a/support_apps/Cargo.toml
+++ b/support_apps/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2018"
 
 [dependencies]
 toml = "0.5"
-nng = "0.5.1"
+nng = "1.0.0"
 rmp = "0.8.9"
-rmp-serde = "0.14.4"
+rmp-serde = "1.0.0"
 control_apps = {path = "../control_apps"}
 simulator = {path = "../simulator"}
 


### PR DESCRIPTION
we were running many minor versions and one major version behind.

WARNING: nng v1.0.1 requires version 3.13+ of CMake

https://nng.nanomsg.org/
> To build this project, you will need a C99 compatible compiler and [CMake](http://www.cmake.org/) version 3.13 or newer.